### PR TITLE
Add simplified groceries example for docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "grocery-notifications-simple"
+version = "0.0.0"
+dependencies = [
+ "fluvio-smartmodule",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "log-level",
     "regex-scrubbing",
     "grocery-notifications",
+    "grocery-notifications-simple",
     "summing-integers",
     "incremental-average",
     "json-array-expansion",

--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ To learn more about SmartModules, visit [the docs on fluvio.io][1].
 
 [1]: https://fluvio.io/docs/smartmodules/overview
 
-| Example | SmartModule | Blog/Guide |
-| --- | --- | --- |
-| [Summing Integers](./summing-integers/src/lib.rs) | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/) | [Blog: Aggregate streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-aggregates/) |
-| [Incremental Average](./incremental-average/src/lib.rs) | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/) | |
-| [Log Level](./log-level/src/lib.rs)| [filter](https://www.fluvio.io/docs/smartstreams/filter/) | [Blog: Write a WASM-based filter for application logs](https://www.infinyon.com/blog/2021/06/smartstream-filters/)|
-| [Regex scrubbing](./regex-scrubbing/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | [Blog: Transforming streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/) |
-| [GitHub Stars](./github-stars/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | [Guide: How to use SmartModules with the HTTP Smart Connector](https://fluvio.io/connectors/examples/github) |
-| [Json-to-Yaml](./json-to-yaml/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | |
-| [Reddit-pagination](./reddit-pagination/src/lib.rs) | [array-map](https://www.fluvio.io/docs/smartstreams/array-map/) | [Blog: Streaming the Reddit API using Fluvio's WASM ArrayMap](https://www.infinyon.com/blog/2021/10/smartstream-array-map-reddit/) |
-| [Json Array Expansion](./json-array-expansion/src/lib.rs) | [array-map](https://www.fluvio.io/docs/smartstreams/array-map/) | |
-| [Grocery Notifications](./grocery-notifications/src/lib.rs) | filter-map | [Blog: Using Fluvio FilterMap to apply focus to real-time data](https://www.infinyon.com/blog/2021/11/filter-map/) |
+| Example                                                                     | SmartModule                                                         | Blog/Guide                                                                                                                          |
+|-----------------------------------------------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| [Summing Integers](./summing-integers/src/lib.rs)                           | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/)     | [Blog: Aggregate streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-aggregates/)       |
+| [Incremental Average](./incremental-average/src/lib.rs)                     | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/)     |                                                                                                                                     |
+| [Log Level](./log-level/src/lib.rs)                                         | [filter](https://www.fluvio.io/docs/smartstreams/filter/)           | [Blog: Write a WASM-based filter for application logs](https://www.infinyon.com/blog/2021/06/smartstream-filters/)                  |
+| [Regex scrubbing](./regex-scrubbing/src/lib.rs)                             | [map](https://www.fluvio.io/docs/smartstreams/map/)                 | [Blog: Transforming streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/) |
+| [GitHub Stars](./github-stars/src/lib.rs)                                   | [map](https://www.fluvio.io/docs/smartstreams/map/)                 | [Guide: How to use SmartModules with the HTTP Smart Connector](https://fluvio.io/connectors/examples/github)                        |
+| [Json-to-Yaml](./json-to-yaml/src/lib.rs)                                   | [map](https://www.fluvio.io/docs/smartstreams/map/)                 |                                                                                                                                     |
+| [Reddit-pagination](./reddit-pagination/src/lib.rs)                         | [array-map](https://www.fluvio.io/docs/smartstreams/array-map/)     | [Blog: Streaming the Reddit API using Fluvio's WASM ArrayMap](https://www.infinyon.com/blog/2021/10/smartstream-array-map-reddit/)  |
+| [Json Array Expansion](./json-array-expansion/src/lib.rs)                   | [array-map](https://www.fluvio.io/docs/smartstreams/array-map/)     |                                                                                                                                     |
+| [Grocery Notifications](./grocery-notifications/src/lib.rs)                 | [filter-map](https://www.fluvio.io/docs/smartstreams/filter-map/)   | [Blog: Using Fluvio FilterMap to apply focus to real-time data](https://www.infinyon.com/blog/2021/11/filter-map/)                  |
+| [Grocery Notifications (simple)](./grocery-notifications-simple/src/lib.rs) | [filter-map](https://www.fluvio.io/docs/smartstreams/filter-map/)   |                                                                                                                                     |
 
 ## Types of SmartModules
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To learn more about SmartModules, visit [the docs on fluvio.io][1].
 | [Summing Integers](./summing-integers/src/lib.rs) | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/) | [Blog: Aggregate streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-aggregates/) |
 | [Incremental Average](./incremental-average/src/lib.rs) | [aggregate](https://www.fluvio.io/docs/smartstreams/aggregate/) | |
 | [Log Level](./log-level/src/lib.rs)| [filter](https://www.fluvio.io/docs/smartstreams/filter/) | [Blog: Write a WASM-based filter for application logs](https://www.infinyon.com/blog/2021/06/smartstream-filters/)|
-| [Regex scrubbing](./regex-scrubbing/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | [Blog: Transforming streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/)
+| [Regex scrubbing](./regex-scrubbing/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | [Blog: Transforming streaming data in real-time with WebAssembly](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/) |
 | [GitHub Stars](./github-stars/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | [Guide: How to use SmartModules with the HTTP Smart Connector](https://fluvio.io/connectors/examples/github) |
 | [Json-to-Yaml](./json-to-yaml/src/lib.rs) | [map](https://www.fluvio.io/docs/smartstreams/map/) | |
 | [Reddit-pagination](./reddit-pagination/src/lib.rs) | [array-map](https://www.fluvio.io/docs/smartstreams/array-map/) | [Blog: Streaming the Reddit API using Fluvio's WASM ArrayMap](https://www.infinyon.com/blog/2021/10/smartstream-array-map-reddit/) |

--- a/grocery-notifications-simple/Cargo.toml
+++ b/grocery-notifications-simple/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "grocery-notifications-simple"
+version = "0.0.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+fluvio-smartmodule = { version = "0.1.0" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/grocery-notifications-simple/src/lib.rs
+++ b/grocery-notifications-simple/src/lib.rs
@@ -1,0 +1,45 @@
+use fluvio_smartmodule::{smartmodule, Record, RecordData, Result};
+use serde::{Deserialize, Serialize};
+
+/// Events that may take place in an online grocery service
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum GroceryEvent {
+    AccountCreated {
+        account_id: String,
+        username: String,
+        preferred_name: String,
+        phone_number: String,
+    },
+    OrderReady {
+        account_id: String,
+        sms_number: String,
+        sms_name: String,
+    },
+}
+
+#[smartmodule(filter_map)]
+fn filter_map(record: &Record) -> Result<Option<(Option<RecordData>, RecordData)>> {
+    let event: GroceryEvent = match serde_json::from_slice(record.value.as_ref()) {
+        Ok(event) => event,
+        Err(_) => return Ok(None), // Skip if we fail to parse JSON
+    };
+
+    let sms_message = match event {
+        GroceryEvent::OrderReady {
+            sms_name,
+            sms_number,
+            ..
+        } => serde_json::json!({
+            "number": sms_number,
+            "message": format!(
+                "Hello {}, your groceries have been collected and are ready to pick up!",
+                sms_name
+            ),
+        }),
+        _ => return Ok(None),
+    };
+
+    let message_json = serde_json::to_string(&sms_message)?;
+    Ok(Some((record.key.clone(), message_json.into())))
+}


### PR DESCRIPTION
This PR adds a more simplified version of the groceries-notifications example from the FilterMap blog, intended to be used with the FilterMap docs.